### PR TITLE
feat: add delete() method to JsonDB for query-based deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- New `delete(**kwargs)` method on `JsonDB` for query-based deletion, returning the number of items removed. `IndexedJsonDB` overrides it to keep the primary key index in sync.
+
 ## [0.3.1] - 2025-11-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ db.add(item)                   # Add new items
 db.find(field=value)           # Query by any field  
 db.delete(field=value)         # Delete items matching criteria, returns count
 db.all()                       # Get all items
-db.save()                      # Manual save (auto-saves on add)
+db.save()                      # Manual save (add and delete auto-save)
 ```
 
 ### IndexedJsonDB - Advanced Storage  

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ db = JsonDB(User, Path("users.json"))
 # Available operations
 db.add(item)                   # Add new items
 db.find(field=value)           # Query by any field  
+db.delete(field=value)         # Delete items matching criteria, returns count
 db.all()                       # Get all items
 db.save()                      # Manual save (auto-saves on add)
 ```
@@ -101,6 +102,7 @@ db.find(id=primary_key)        # Optimized primary key search
 ```python
 db.add(item: T) -> T                    # Add new item, auto-saves
 db.find(**kwargs) -> List[T]            # Query by any field  
+db.delete(**kwargs) -> int              # Delete matching items, returns count, auto-saves
 db.all() -> List[T]                     # Get all items
 db.save() -> None                       # Manual save
 ```

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -250,6 +250,43 @@ class JsonDB(Generic[T]):
 
         return results
 
+    def delete(self, **kwargs: Any) -> int:
+        """
+        Delete all items matching the given criteria.
+
+        Args:
+            **kwargs: Field/value pairs an item must match to be deleted.
+
+        Returns:
+            The number of items deleted.
+
+        Raises:
+            JsonDBException: If no criteria are provided.
+        """
+        if not kwargs:
+            raise JsonDBException(
+                "delete() requires at least one criterion to avoid accidentally "
+                "deleting all items."
+            )
+
+        kept: List[T] = []
+        deleted = 0
+        for item in self.data:
+            match = all(
+                hasattr(item, key) and getattr(item, key) == value
+                for key, value in kwargs.items()
+            )
+            if match:
+                deleted += 1
+            else:
+                kept.append(item)
+
+        if deleted:
+            self.data = kept
+            self.save()
+
+        return deleted
+
     def add(self, item: T) -> T:
         """
         Add an item to the database.
@@ -414,6 +451,27 @@ class IndexedJsonDB(JsonDB[T], Generic[T, PK]):
                 return item
 
         raise JsonDBException(f"Item with {self.primary_key}='{key_value}' not found")
+
+    def delete(self, **kwargs: Any) -> int:
+        """
+        Delete all items matching the given criteria.
+
+        Args:
+            **kwargs: Field/value pairs an item must match to be deleted.
+
+        Returns:
+            The number of items deleted.
+
+        Raises:
+            JsonDBException: If no criteria are provided.
+        """
+        deleted = super().delete(**kwargs)
+
+        # Indices may have shifted, so rebuild the primary key index.
+        if deleted:
+            self._rebuild_primary_key_index()
+
+        return deleted
 
     def remove(self, key_value: PK) -> bool:
         """Remove an item by primary key value."""

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -230,6 +230,14 @@ class JsonDB(Generic[T]):
         """Get all items."""
         return self.data.copy()
 
+    @staticmethod
+    def _matches(item: T, criteria: Dict[str, Any]) -> bool:
+        """Return True if the item matches every field/value pair in criteria."""
+        return all(
+            hasattr(item, key) and getattr(item, key) == value
+            for key, value in criteria.items()
+        )
+
     def find(self, **kwargs: Any) -> List[T]:
         """Find items matching the given criteria."""
         if not kwargs:
@@ -238,17 +246,7 @@ class JsonDB(Generic[T]):
             )
 
         # Linear search for all criteria
-        results = []
-        for item in self.data:
-            match = True
-            for key, value in kwargs.items():
-                if not hasattr(item, key) or getattr(item, key) != value:
-                    match = False
-                    break
-            if match:
-                results.append(item)
-
-        return results
+        return [item for item in self.data if self._matches(item, kwargs)]
 
     def delete(self, **kwargs: Any) -> int:
         """
@@ -272,11 +270,7 @@ class JsonDB(Generic[T]):
         kept: List[T] = []
         deleted = 0
         for item in self.data:
-            match = all(
-                hasattr(item, key) and getattr(item, key) == value
-                for key, value in kwargs.items()
-            )
-            if match:
+            if self._matches(item, kwargs):
                 deleted += 1
             else:
                 kept.append(item)

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -459,6 +459,11 @@ class IndexedJsonDB(JsonDB[T], Generic[T, PK]):
         Raises:
             JsonDBException: If no criteria are provided.
         """
+        # Fast-path primary-key-only deletion via the O(1) index, mirroring find().
+        # remove() already updates the index and saves.
+        if len(kwargs) == 1 and self.primary_key in kwargs:
+            return 1 if self.remove(kwargs[self.primary_key]) else 0
+
         deleted = super().delete(**kwargs)
 
         # Indices may have shifted, so rebuild the primary key index.

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -320,6 +320,59 @@ class TestJsonDB:
         assert len(results) == 1
         assert results[0].name == "Test Item"
 
+    def test_delete_items(self, populated_db_no_pk):
+        """Test deleting items matching a single criterion."""
+        deleted = populated_db_no_pk.delete(status=ItemStatus.ACTIVE)
+
+        # All 3 items had status=ACTIVE
+        assert deleted == 3
+        assert len(populated_db_no_pk.data) == 0
+
+        # Verify the change was persisted to disk
+        with open(populated_db_no_pk.file_path, "r") as f:
+            assert json.load(f) == []
+
+    def test_delete_items_multiple_criteria(self, populated_db_no_pk):
+        """Test deleting items matching multiple criteria."""
+        deleted = populated_db_no_pk.delete(status=ItemStatus.ACTIVE, quantity=2)
+
+        # Only one item has quantity=2
+        assert deleted == 1
+        assert len(populated_db_no_pk.data) == 2
+        assert all(item.quantity != 2 for item in populated_db_no_pk.data)
+
+    def test_delete_no_matches(self, populated_db_no_pk):
+        """Test that deleting with no matches changes nothing."""
+        deleted = populated_db_no_pk.delete(status=ItemStatus.COMPLETED)
+
+        assert deleted == 0
+        assert len(populated_db_no_pk.data) == 3
+
+    def test_delete_requires_criteria(self, populated_db_no_pk):
+        """Test that delete() requires at least one criterion."""
+        with pytest.raises(JsonDBException) as exc_info:
+            populated_db_no_pk.delete()
+
+        assert "delete() requires at least one criterion" in str(exc_info.value)
+        # Nothing should have been deleted
+        assert len(populated_db_no_pk.data) == 3
+
+    def test_delete_updates_primary_key_index(self, populated_db):
+        """Test that delete() keeps the IndexedJsonDB primary key index in sync."""
+        remaining = populated_db.find(quantity=1)[0]
+        survivor_id = remaining.id
+
+        deleted = populated_db.delete(quantity=2)
+        assert deleted == 1
+
+        # The index should still resolve the survivor and not the deleted item
+        assert populated_db.get(survivor_id) is not None
+        assert populated_db.get(survivor_id).id == survivor_id
+
+        # Index entries must point at valid positions for every remaining item
+        for item in populated_db.data:
+            assert populated_db.get(item.id) is item
+
     def test_all_items_with_primary_key(self, populated_db):
         """Test retrieving all items."""
         # Get all items

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -373,6 +373,26 @@ class TestJsonDB:
         for item in populated_db.data:
             assert populated_db.get(item.id) is item
 
+    def test_delete_by_primary_key(self, populated_db):
+        """Test deleting by primary key only (fast-path via the index)."""
+        target = populated_db.all()[0]
+
+        deleted = populated_db.delete(id=target.id)
+
+        assert deleted == 1
+        assert populated_db.get(target.id) is None
+        assert len(populated_db.data) == 2
+        # Remaining items must still resolve through the index
+        for item in populated_db.data:
+            assert populated_db.get(item.id) is item
+
+    def test_delete_by_nonexistent_primary_key(self, populated_db):
+        """Test deleting by a primary key that does not exist."""
+        deleted = populated_db.delete(id=uuid.uuid4())
+
+        assert deleted == 0
+        assert len(populated_db.data) == 3
+
     def test_all_items_with_primary_key(self, populated_db):
         """Test retrieving all items."""
         # Get all items


### PR DESCRIPTION
## Summary

Adds a `delete(**kwargs)` method to `JsonDB`, completing basic CRUD. Previously the base `JsonDB` was effectively append-only — deletion only existed on `IndexedJsonDB.remove()` and required a primary key.

`delete()` mirrors the existing `find()` API:
- Removes all items matching the given criteria, auto-saves, and returns the count deleted.
- Raises `JsonDBException` if called with no criteria, guarding against accidentally clearing the database.
- `IndexedJsonDB` overrides it to rebuild the primary key index after removal (list positions shift).

## Usage

```python
deleted = db.delete(status="inactive")  # returns number removed
```

## Tests

Added 5 tests covering single/multiple criteria, no-match no-op, the empty-criteria guard, and primary-key index consistency on `IndexedJsonDB`. Full suite passes (68 tests); `ruff check` and `ruff format --check` are clean.

## Docs

- README: usage snippet + API Reference updated.
- CHANGELOG: new `[Unreleased]` entry.