### PR TITLE
feat: add count() and Pythonic protocols to JsonDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `delete(**kwargs)` method on `JsonDB` for query-based deletion, returning the number of items removed. `IndexedJsonDB` overrides it to keep the primary key index in sync.
+- New `count(**kwargs)` method on `JsonDB` returning the number of items, optionally filtered by criteria.
+- Pythonic protocol support on `JsonDB`: `len(db)`, iteration (`for item in db`), and membership testing (`item in db`).
 
 ## [0.3.1] - 2025-11-24
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,14 @@ db = JsonDB(User, Path("users.json"))
 db.add(item)                   # Add new items
 db.find(field=value)           # Query by any field  
 db.delete(field=value)         # Delete items matching criteria, returns count
+db.count(field=value)          # Count items (all, or matching criteria)
 db.all()                       # Get all items
 db.save()                      # Manual save (add and delete auto-save)
+
+# Pythonic helpers
+len(db)                        # Number of items
+for item in db: ...            # Iterate over items
+item in db                     # Membership test
 ```
 
 ### IndexedJsonDB - Advanced Storage  
@@ -103,8 +109,12 @@ db.find(id=primary_key)        # Optimized primary key search
 db.add(item: T) -> T                    # Add new item, auto-saves
 db.find(**kwargs) -> List[T]            # Query by any field  
 db.delete(**kwargs) -> int              # Delete matching items, returns count, auto-saves
+db.count(**kwargs) -> int               # Count all items, or those matching criteria
 db.all() -> List[T]                     # Get all items
 db.save() -> None                       # Manual save
+len(db) -> int                          # Number of items
+iter(db) -> Iterator[T]                 # Iterate over items
+item in db -> bool                      # Membership test
 ```
 
 ### IndexedJsonDB Additional Methods

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Dict,
     Generic,
+    Iterator,
     List,
     Optional,
     Type,
@@ -230,6 +231,18 @@ class JsonDB(Generic[T]):
         """Get all items."""
         return self.data.copy()
 
+    def __len__(self) -> int:
+        """Return the number of items in the database."""
+        return len(self.data)
+
+    def __iter__(self) -> Iterator[T]:
+        """Iterate over the items in the database."""
+        return iter(self.data)
+
+    def __contains__(self, item: object) -> bool:
+        """Return True if the given item is stored in the database."""
+        return item in self.data
+
     @staticmethod
     def _matches(item: T, criteria: Dict[str, Any]) -> bool:
         """Return True if the item matches every field/value pair in criteria."""
@@ -247,6 +260,22 @@ class JsonDB(Generic[T]):
 
         # Linear search for all criteria
         return [item for item in self.data if self._matches(item, kwargs)]
+
+    def count(self, **kwargs: Any) -> int:
+        """
+        Count items, optionally filtered by criteria.
+
+        Args:
+            **kwargs: Optional field/value pairs to match. With no criteria,
+                counts all items.
+
+        Returns:
+            The number of matching items.
+        """
+        if not kwargs:
+            return len(self.data)
+
+        return sum(1 for item in self.data if self._matches(item, kwargs))
 
     def delete(self, **kwargs: Any) -> int:
         """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -393,6 +393,48 @@ class TestJsonDB:
         assert deleted == 0
         assert len(populated_db.data) == 3
 
+    def test_count_all(self, populated_db_no_pk):
+        """Test counting all items with no criteria."""
+        assert populated_db_no_pk.count() == 3
+
+    def test_count_empty_db(self, temp_db_path):
+        """Test counting an empty database."""
+        db = JsonDB(SampleItem, temp_db_path)
+        assert db.count() == 0
+
+    def test_count_with_criteria(self, populated_db_no_pk):
+        """Test counting items matching criteria."""
+        assert populated_db_no_pk.count(status=ItemStatus.ACTIVE) == 3
+        assert populated_db_no_pk.count(quantity=2) == 1
+        assert populated_db_no_pk.count(status=ItemStatus.COMPLETED) == 0
+
+    def test_len(self, populated_db_no_pk):
+        """Test that len() returns the number of items."""
+        assert len(populated_db_no_pk) == 3
+
+    def test_len_empty_db(self, temp_db_path):
+        """Test that len() is zero for an empty database."""
+        db = JsonDB(SampleItem, temp_db_path)
+        assert len(db) == 0
+
+    def test_iter(self, populated_db_no_pk):
+        """Test iterating over the database yields all items."""
+        items = list(populated_db_no_pk)
+        assert len(items) == 3
+        assert items == populated_db_no_pk.all()
+
+    def test_contains(self, temp_db_path, sample_item):
+        """Test membership testing with the `in` operator."""
+        db = JsonDB(SampleItem, temp_db_path)
+        db.add(sample_item)
+
+        assert sample_item in db
+
+        other = SampleItem(
+            id=uuid.uuid4(), name="Other", status=ItemStatus.ACTIVE, quantity=1
+        )
+        assert other not in db
+
     def test_all_items_with_primary_key(self, populated_db):
         """Test retrieving all items."""
         # Get all items


### PR DESCRIPTION
## Summary

Follow-up to the `delete()` PR, adding the remaining suggested conveniences:

- **`count(**kwargs) -> int`** — returns the number of items, optionally filtered by criteria (`count()` for the total, `count(status="active")` for matches). Reuses the shared `_matches` helper.
- **Pythonic protocols on `JsonDB`** — `__len__`, `__iter__`, `__contains__`, so callers can use `len(db)`, `for item in db`, and `item in db`.

All are read-only and inherited by `IndexedJsonDB` unchanged.

## Tests

Added 7 tests: `count()` (all / filtered / empty), `len()` (populated / empty), iteration, and membership. Full suite passes (77 tests); `ruff check` and `ruff format --check` clean.

## Docs

- README: usage snippet + API Reference updated.
- CHANGELOG: entries added under `[Unreleased]`.