### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-06-26
 
 ### Added
 - New `delete(**kwargs)` method on `JsonDB` for query-based deletion, returning the number of items removed. `IndexedJsonDB` overrides it to keep the primary key index in sync.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-json-db"
-version = "0.3.1"
+version = "0.4.0"
 description = "A simple JSON-based database for Python applications"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Release **0.4.0**.

Merging this to `main` triggers `deploy-pypi.yml`, which builds, publishes `typed-json-db==0.4.0` to PyPI, and creates the `v0.4.0` tag + GitHub release.

## Version
- `pyproject.toml`: `0.3.1` → `0.4.0` (minor — new backward-compatible features)
- CHANGELOG: `[Unreleased]` finalized as `[0.4.0] - 2026-06-26`

## Included since 0.3.1
- `delete(**kwargs)` query-based deletion on `JsonDB` (#30)
- `count(**kwargs)` and Pythonic protocols `len()` / iteration / membership on `JsonDB` (#31)

## Verification
- 77 tests pass
- `uv build` produces `typed_json_db-0.4.0` sdist + wheel