### PR TITLE
Roll back in-memory changes when a save fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - A save that cannot be serialized no longer corrupts the database file. Serialization now completes in memory before the file is opened, so an item the serializer cannot encode leaves the previous contents intact and readable instead of truncating the file mid-write. Circular and self-referential values now also raise `JsonDBException` rather than propagating a `ValueError` or `RecursionError`.
+- A failed save no longer leaves the in-memory data out of step with the file. `add()`, `update()`, `delete()` and `remove()` now roll back their change when it cannot be saved, so the database stays usable instead of raising on every later save, and `IndexedJsonDB` no longer keeps a key in its items while missing it from the primary key index — which allowed a duplicate primary key to be added and persisted.
 
 ## [0.4.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - A save that cannot be serialized no longer corrupts the database file. Serialization now completes in memory before the file is opened, so an item the serializer cannot encode leaves the previous contents intact and readable instead of truncating the file mid-write. Circular and self-referential values now also raise `JsonDBException` rather than propagating a `ValueError` or `RecursionError`.
-- A failed save no longer leaves the in-memory data out of step with the file. `add()`, `update()`, `delete()` and `remove()` now roll back their change when it cannot be saved, so the database stays usable instead of raising on every later save, and `IndexedJsonDB` no longer keeps a key in its items while missing it from the primary key index — which allowed a duplicate primary key to be added and persisted.
+- A save that cannot be serialized no longer leaves the in-memory data out of step with the file. `add()`, `update()`, `delete()` and `remove()` now roll back their change when serialization fails, so the database stays usable instead of raising on every later save, and `IndexedJsonDB` no longer keeps a key in its items while missing it from the primary key index — which allowed a duplicate primary key to be added and persisted. I/O errors while writing are unaffected and still propagate without a rollback.
 
 ## [0.4.0] - 2026-06-26
 

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -240,6 +240,30 @@ class JsonDB(Generic[T]):
         """Save current data to the file."""
         self._save(self.data)
 
+    def _save_or_rollback(self, snapshot: List[T]) -> None:
+        """
+        Save current data, restoring `snapshot` if it cannot be saved.
+
+        A failed save leaves the file untouched, so the in-memory data must be
+        rewound too or the two would disagree and every later save would fail on
+        the same unserializable item.
+
+        Args:
+            snapshot: The item list to restore if the save fails.
+
+        Raises:
+            JsonDBException: If the data cannot be serialized, after rolling back.
+        """
+        try:
+            self.save()
+        except JsonDBException:
+            self.data = snapshot
+            self._after_rollback()
+            raise
+
+    def _after_rollback(self) -> None:
+        """Restore state derived from `self.data` after a rollback. No-op here."""
+
     def all(self) -> List[T]:
         """Get all items."""
         return self.data.copy()
@@ -318,8 +342,9 @@ class JsonDB(Generic[T]):
                 kept.append(item)
 
         if deleted:
+            snapshot = self.data
             self.data = kept
-            self.save()
+            self._save_or_rollback(snapshot)
 
         return deleted
 
@@ -334,7 +359,8 @@ class JsonDB(Generic[T]):
             The added item
 
         Raises:
-            JsonDBException: If the item is not of the expected type or primary key already exists
+            JsonDBException: If the item is not of the expected type, or cannot be
+                serialized, in which case the database is left unchanged.
         """
         if not isinstance(item, self.data_class):
             raise JsonDBException(
@@ -351,8 +377,9 @@ class JsonDB(Generic[T]):
         if updates:
             item = replace(item, **updates)
 
+        snapshot = list(self.data)
         self.data.append(item)
-        self.save()
+        self._save_or_rollback(snapshot)
 
         return item
 
@@ -391,6 +418,10 @@ class IndexedJsonDB(JsonDB[T], Generic[T, PK]):
         super().__init__(data_class, file_path)
 
         # Build primary key index
+        self._rebuild_primary_key_index()
+
+    def _after_rollback(self) -> None:
+        """Rebuild the primary key index, whose positions follow `self.data`."""
         self._rebuild_primary_key_index()
 
     def get(self, key_value: PK) -> Optional[T]:
@@ -482,8 +513,9 @@ class IndexedJsonDB(JsonDB[T], Generic[T, PK]):
                 hasattr(existing_item, self.primary_key)
                 and getattr(existing_item, self.primary_key) == key_value
             ):
+                snapshot = list(self.data)
                 self.data[i] = item
-                self.save()
+                self._save_or_rollback(snapshot)
                 return item
 
         raise JsonDBException(f"Item with {self.primary_key}='{key_value}' not found")
@@ -521,12 +553,13 @@ class IndexedJsonDB(JsonDB[T], Generic[T, PK]):
                 hasattr(item, self.primary_key)
                 and getattr(item, self.primary_key) == key_value
             ):
+                snapshot = list(self.data)
                 self.data.pop(i)
 
                 # Rebuild primary key index since indices have shifted
                 self._rebuild_primary_key_index()
 
-                self.save()
+                self._save_or_rollback(snapshot)
                 return True
         return False
 

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -555,11 +555,11 @@ class IndexedJsonDB(JsonDB[T], Generic[T, PK]):
             ):
                 snapshot = list(self.data)
                 self.data.pop(i)
-
-                # Rebuild primary key index since indices have shifted
-                self._rebuild_primary_key_index()
-
                 self._save_or_rollback(snapshot)
+
+                # Rebuild primary key index since indices have shifted. A failed
+                # save rebuilds it from the restored items instead.
+                self._rebuild_primary_key_index()
                 return True
         return False
 

--- a/src/typed_json_db/database.py
+++ b/src/typed_json_db/database.py
@@ -242,17 +242,22 @@ class JsonDB(Generic[T]):
 
     def _save_or_rollback(self, snapshot: List[T]) -> None:
         """
-        Save current data, restoring `snapshot` if it cannot be saved.
+        Save current data, restoring `snapshot` if serialization fails.
 
-        A failed save leaves the file untouched, so the in-memory data must be
-        rewound too or the two would disagree and every later save would fail on
-        the same unserializable item.
+        Serialization leaves the file untouched when it fails, so the in-memory
+        data must be rewound too or the two would disagree and every later save
+        would fail on the same unserializable item.
+
+        Only serialization failures roll back. An I/O error while writing
+        propagates as-is, leaving `self.data` modified, because the file may
+        already be partially written and no in-memory state matches it.
 
         Args:
-            snapshot: The item list to restore if the save fails.
+            snapshot: The item list to restore if serialization fails.
 
         Raises:
             JsonDBException: If the data cannot be serialized, after rolling back.
+            OSError: If the file cannot be written, without rolling back.
         """
         try:
             self.save()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1635,7 +1635,10 @@ class TestFailedSaveRollback:
 
         # The database is not wedged: a later valid add still persists
         db.add(PayloadItem(name="later"))
-        assert [record["name"] for record in json.loads(temp_db_path.read_text())] == [
+        assert [
+            record["name"]
+            for record in json.loads(temp_db_path.read_text(encoding="utf-8"))
+        ] == [
             "kept",
             "later",
         ]
@@ -1652,7 +1655,10 @@ class TestFailedSaveRollback:
 
         # Because the key really is absent, re-adding it cannot duplicate it
         keyed_db.add(KeyedPayloadItem(id="c"))
-        assert [record["id"] for record in json.loads(temp_db_path.read_text())] == [
+        assert [
+            record["id"]
+            for record in json.loads(temp_db_path.read_text(encoding="utf-8"))
+        ] == [
             "a",
             "b",
             "c",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1598,3 +1598,99 @@ class TestSaveSerializationFailure:
 
         reopened: JsonDB[PayloadItem] = JsonDB(PayloadItem, temp_db_path)
         assert reopened.all()[0].name == "Ångström ✓"
+
+
+@dataclass
+class KeyedPayloadItem:
+    """Keyed item with an untyped payload, used to trigger serialization errors."""
+
+    id: str = ""
+    payload: Optional[Any] = None
+
+
+class TestFailedSaveRollback:
+    """A failed save must rewind memory so it keeps matching the file."""
+
+    @pytest.fixture
+    def keyed_db(self, temp_db_path):
+        """An indexed database holding two keyed records."""
+        db: IndexedJsonDB[KeyedPayloadItem, str] = IndexedJsonDB(
+            KeyedPayloadItem, temp_db_path, primary_key="id"
+        )
+        db.add(KeyedPayloadItem(id="a"))
+        db.add(KeyedPayloadItem(id="b"))
+        return db
+
+    def test_failed_add_leaves_database_usable(self, temp_db_path):
+        """The rejected item is dropped from memory, so later saves still work."""
+        db: JsonDB[PayloadItem] = JsonDB(PayloadItem, temp_db_path)
+        db.add(PayloadItem(name="kept"))
+
+        with pytest.raises(JsonDBException):
+            db.add(PayloadItem(name="bad", payload=object()))
+
+        # Memory matches the file rather than holding the unsaveable item
+        assert len(db) == 1
+        assert [item.name for item in db.all()] == ["kept"]
+
+        # The database is not wedged: a later valid add still persists
+        db.add(PayloadItem(name="later"))
+        assert [record["name"] for record in json.loads(temp_db_path.read_text())] == [
+            "kept",
+            "later",
+        ]
+
+    def test_failed_add_keeps_primary_key_index_consistent(
+        self, keyed_db, temp_db_path
+    ):
+        """A rolled back add must not leave the key in data but missing from the index."""
+        with pytest.raises(JsonDBException):
+            keyed_db.add(KeyedPayloadItem(id="c", payload=object()))
+
+        assert keyed_db.get("c") is None
+        assert [item.id for item in keyed_db.all()] == ["a", "b"]
+
+        # Because the key really is absent, re-adding it cannot duplicate it
+        keyed_db.add(KeyedPayloadItem(id="c"))
+        assert [record["id"] for record in json.loads(temp_db_path.read_text())] == [
+            "a",
+            "b",
+            "c",
+        ]
+        assert keyed_db.get("c") is not None
+
+    def test_failed_update_keeps_previous_item(self, keyed_db, temp_db_path):
+        """A failed update leaves the stored item in place."""
+        contents_before = temp_db_path.read_text(encoding="utf-8")
+
+        with pytest.raises(JsonDBException):
+            keyed_db.update(KeyedPayloadItem(id="a", payload=object()))
+
+        stored = keyed_db.get("a")
+        assert stored is not None and stored.payload is None
+        assert temp_db_path.read_text(encoding="utf-8") == contents_before
+
+    def test_failed_delete_keeps_items(self, keyed_db, temp_db_path):
+        """A delete whose save fails restores the items it removed."""
+        # Stored items are handed out by reference, so this poisons the database
+        keyed_db.all()[0].payload = object()
+        contents_before = temp_db_path.read_text(encoding="utf-8")
+
+        with pytest.raises(JsonDBException):
+            keyed_db.delete(id="b")
+
+        assert [item.id for item in keyed_db.all()] == ["a", "b"]
+        assert temp_db_path.read_text(encoding="utf-8") == contents_before
+
+    def test_failed_remove_keeps_item_and_index(self, keyed_db, temp_db_path):
+        """A remove whose save fails restores both the item and its index entry."""
+        keyed_db.all()[0].payload = object()
+        contents_before = temp_db_path.read_text(encoding="utf-8")
+
+        with pytest.raises(JsonDBException):
+            keyed_db.remove("b")
+
+        assert [item.id for item in keyed_db.all()] == ["a", "b"]
+        restored = keyed_db.get("b")
+        assert restored is not None and restored.id == "b"
+        assert temp_db_path.read_text(encoding="utf-8") == contents_before


### PR DESCRIPTION
Follow-up to the review of #36, fixing the significant finding that PR left open: #36 makes the **file** safe when serialization fails, but the **in-memory** state was still left holding the change.

> Originally stacked on #36. Now that #36 has been squash-merged, these two commits have been rebased onto `main` and the base retargeted, so this diff is the rollback change alone.

## The bug

Every mutator appended to or reassigned `self.data` *before* calling `save()`. When the save could not serialize, memory kept an item the file does not have:

```python
db.add(Row(name="kept"))
try:
    db.add(Row(name="bad", payload=object()))   # raises JsonDBException
except JsonDBException:
    pass

len(db)                       # 2 — but the file holds 1
db.add(Row(name="later"))     # raises: the poisoned item is still in self.data
db.save()                     # raises, forever
```

The database is wedged. The unsaveable item stays in `self.data`, so every later `add()`, `update()`, `delete()` and `save()` raises on it, and `all()`/`len()` report a record that was never persisted.

`IndexedJsonDB` was worse, because `add()` only records the key in `_primary_key_index` *after* `super().add()` returns. A failed save left the key present in `self.data` but absent from the index, so `get()` reported the key as free and the uniqueness check in `add()` passed for a key that was already there:

```python
db.add(KRow(id="a"))
try:
    db.add(KRow(id="b", payload=object()))   # fails to serialize
except JsonDBException:
    pass

db.get("b")                   # None — but 'b' IS in db.all()
db.add(KRow(id="b"))          # accepted; uniqueness check bypassed
# data ids: ['a', 'b', 'b']  →  duplicate reaches the file once the poisoned item goes
```

That last line is the real damage: a duplicate primary key persisted to disk, verified end to end.

## The fix

A single helper that keeps memory and file in step, plus a hook for state derived from `self.data`:

```python
def _save_or_rollback(self, snapshot: List[T]) -> None:
    try:
        self.save()
    except JsonDBException:
        self.data = snapshot
        self._after_rollback()
        raise
```

`add()`, `delete()`, `update()` and `remove()` now route through it. `IndexedJsonDB` overrides `_after_rollback()` to call its existing `_rebuild_primary_key_index()`, since index positions follow `self.data`.

No public API or signature changes, and no change to the on-disk format — the only behavioural difference is what memory looks like after a save that raises.

## When this actually triggers

`JsonSerializer.default` handles only UUID, `datetime`/`date` and `Enum`, so any other type in a field raises `TypeError`: `Decimal`, `Path`, `set`, `bytes`, `timedelta`, `complex`, or any plain object — all verified. The realistic route in is schema growth (someone adds `total: Decimal`) or an `Any`-typed field carrying a value from outside the program. Deeply nested structures hit `RecursionError`. Rare per-operation, but the consequence was disproportionate.

## Tests

Five regression tests covering each mutator:

- **`add`** — the rejected item is dropped, and a later valid `add` still persists, proving the database is not wedged.
- **`add` on `IndexedJsonDB`** — `get()` and `all()` agree, and re-adding that key afterwards cannot duplicate it.
- **`update`** — the previously stored item survives, file byte-unchanged.
- **`delete`** and **`remove`** — the removed items are restored, index entries included.

Reaching the `delete`/`remove` paths needs an unserializable item already in the database, which `add()` now refuses to leave behind — so those two tests poison a stored item through the reference `all()` hands out (items are shared, not deep-copied). Worth knowing that's possible at all.

## Checks

86 tests pass; `ruff format --check` and `ruff check` clean. The repo configures no type checker, so mypy was run ad-hoc: 3 errors, all pre-existing unbound-`TypeVar` complaints in unrelated `asdict`/`replace` calls, unchanged from before this diff.

## Known gap, not addressed here

`_save_or_rollback` catches `JsonDBException` only, and the `open`/`write` sits outside `_save`'s `try` — so an **I/O failure does not roll back**. Verified: replacing the file with a directory raises `IsADirectoryError` unwrapped and memory keeps the change. The same applies to ENOSPC, EACCES, and a read-only filesystem. Widening the catch to `(JsonDBException, OSError)` would make the open-failure case exact; it is left out pending a decision, since it changes behaviour for I/O errors and may belong in its own change alongside atomic writes.

Also still out of scope: atomic writes (temp file + `os.replace`) and `fsync` — a crash or ENOSPC mid-`write` can truncate the file, which no in-memory rollback addresses. And `_load` reading without an explicit encoding, plus its missing `from e` on the re-raise.